### PR TITLE
introduce better interactions route /api/u for formatted interactions

### DIFF
--- a/src/hn_follow/core/api.clj
+++ b/src/hn_follow/core/api.clj
@@ -47,6 +47,28 @@
       (take n (drop skip
                     (interactions (or user {})))))))
 
+(defn- tree-template [tree]
+  (let [root-item (first (filter #(= "story" (% "type")) tree))
+        latest (first tree)]
+    {:by (latest "by")
+     :id (latest "id")
+     :parent (latest "parent")
+     :root (root-item "id")
+     :type (latest "type")
+     :title (root-item "title")
+     :url (root-item "url")
+     :time (latest "time")
+     :text (latest "text")}))
+
+(defn interaction-feed
+  ([user] (interaction-feed user 0 10))
+  ([user skip n]
+     (let [tree (interaction-tree user skip n)
+           clean (map #(% :tree) tree)
+           ;; Remove any deleted comments now
+           valid (map #(filter (fn [x] (nil? (x "deleted"))) %) clean)]
+       (map tree-template valid))))
+
 ;
 ; Realtime API
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/hn_follow/core/handler.clj
+++ b/src/hn_follow/core/handler.clj
@@ -47,6 +47,12 @@
                       offset (* 5 (dec page))] ;; Dec page so 1->0,2->5
                   (json {:interactions
                          (-> (params :user) api/get-user (api/interaction-tree offset 5))})))
+
+           (GET "/u/:user" {params :params}
+                (let [page (str->int (params :page))
+                      offset (* 5 (dec page))] ;; Dec page so 1->0,2->5
+                  (json {:interactions
+                         (-> (params :user) api/get-user (api/interaction-feed offset 5))})))
            
            (POST "/u" {body :body}
                  (let [request (parse-string (slurp body) true)]


### PR DESCRIPTION
Now you can use the `/api/u/:user` route to get formatted interactions. Here's what the new route looks like:

```
{ 
  interactions: [
    {
    parent: 8698858,
    time: 1417703735,
    type: "comment",
    title: "Orion flight test rescheduled for tomorrow",
    root: 8698587,
    id: 8699356,
    url: "http://www.nasa.gov/multimedia/nasatv/#.VIAwicl5V8F",
    by: "film42",
    text: "UDATE: 24-hr re-cycle."
    },
    {
    parent: null,
    time: 1417546348,
    type: "story",
    title: "Reflections on Trusting Trust (1984)",
    root: 8688983,
    id: 8688983,
    url: "http://www.win.tue.nl/~aeb/linux/hh/thompson/trust.html",
    by: "film42",
    text: ""
    },

  ...
```

Now @Baconbits and @qzcx can focus on rewriting the little bits of JS now.

Note: Pagination still works :)
